### PR TITLE
Fix building on GCC 5+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
 endif()
 externalproject_add(rsxs SOURCE_DIR ${PROJECT_SOURCE_DIR}/${rsxs_dir}
                     CONFIGURE_COMMAND ${configure_start}
+                                      ac_cv_type__Bool=yes
                                       --prefix=<INSTALL_DIR>
                                       --without-xscreensaver
                                       --disable-cyclone


### PR DESCRIPTION
Arch currently carries this patch: https://git.archlinux.org/svntogit/community.git/tree/trunk/0001-fix-gcc5-compile.patch?h=packages/kodi-addon-screensaver-rsxs&id=c185cdef5e0f282e3993d201ef3ae0f5eed02975

Also necessary on Gentoo as reported at https://bugs.gentoo.org/show_bug.cgi?id=605244