### PR TITLE
pass format specifier to __argp_error

### DIFF
--- a/lib/rsxs-1.0/lib/argp-parse.c
+++ b/lib/rsxs-1.0/lib/argp-parse.c
@@ -154,7 +154,7 @@ argp_version_parser (int key, char *arg, struct argp_state *state)
       else if (argp_program_version)
 	fprintf (state->out_stream, "%s\n", argp_program_version);
       else
-	__argp_error (state, dgettext (state->root_argp->argp_domain,
+	__argp_error (state, "%s", dgettext (state->root_argp->argp_domain,
 				       "(PROGRAM ERROR) No version known!?"));
       if (! (state->flags & ARGP_NO_EXIT))
 	exit (0);


### PR DESCRIPTION
Fixes compile with -Werror=format-security (ie. newer debian packaging compat levels imply this).