### PR TITLE
Fix compile on normal systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,20 @@ build/
 obj-x86_64-linux-gnu/
 screensaver.rsxs.*/addon.xml
 
+# Prevent add of with autoreconf generated files
+Makefile.in
+lib/rsxs-1.0/INSTALL
+lib/rsxs-1.0/aclocal.m4
+lib/rsxs-1.0/autom4te.cache
+lib/rsxs-1.0/compile
+lib/rsxs-1.0/config.guess
+lib/rsxs-1.0/config.h.in
+lib/rsxs-1.0/config.sub
+lib/rsxs-1.0/configure
+lib/rsxs-1.0/depcomp
+lib/rsxs-1.0/install-sh
+lib/rsxs-1.0/missing
+
 # commonly used editors
 # vim
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,12 @@ matrix:
       dist: xenial
       sudo: required
       compiler: clang
-    - os: osx
-      osx_image: xcode9
 
 #
 # Some of the OS X images don't have cmake, contrary to what people
 # on the Internet say
 #
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y freeglut3-dev libxmu-headers; fi
 
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libgl1-mesa-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y freeglut3-dev libxmu-headers; fi
 
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,6 @@ include_directories(${OpenGL_INCLUDE_DIR}
                     ${PROJECT_SOURCE_DIR}/${rsxs_dir}/src/plasma
                     ${PROJECT_SOURCE_DIR}/${rsxs_dir}/src/skyrocket
                     ${PROJECT_SOURCE_DIR}/${rsxs_dir}/src/solarwinds)
-                        
-
-get_filename_component( COMPILER_FILENAME "${CMAKE_C_COMPILER}" NAME )
-string( REGEX REPLACE "-[^-]+$" ""
-        TOOLCHAIN_NAME "${COMPILER_FILENAME}" )
 
 include(ExternalProject)
 set(update_command "")
@@ -55,13 +50,21 @@ if(APPLE)
 else()
   set(EXTRA_FLAGS "CFLAGS=${CMAKE_C_FLAGS} -fPIC -I${KODI_INCLUDE_DIR}" "CXXFLAGS=${CMAKE_CXX_FLAGS} -fPIC -I${KODI_INCLUDE_DIR}")
 endif()
+
+get_filename_component(COMPILER_FILENAME "${CMAKE_C_COMPILER}" NAME )
+if(NOT ${COMPILER_FILENAME} MATCHES "cc" AND
+   NOT ${COMPILER_FILENAME} MATCHES "clang")
+  string( REGEX REPLACE "-[^-]+$" ""
+          TOOLCHAIN_NAME "${COMPILER_FILENAME}" )
+  list(APPEND EXTRA_FLAGS "--host=${TOOLCHAIN_NAME}")
+endif()
+
 externalproject_add(rsxs SOURCE_DIR ${PROJECT_SOURCE_DIR}/${rsxs_dir}
                     CONFIGURE_COMMAND ${configure_start}
                                       ac_cv_type__Bool=yes
                                       gl_cv_func_gettimeofday_clobber=no
                                       ac_cv_func_malloc_0_nonnull=yes
                                       --prefix=<INSTALL_DIR>
-                                      --host=${TOOLCHAIN_NAME}
                                       --without-xscreensaver
                                       --disable-cyclone
                                       --disable-euphoria


### PR DESCRIPTION
This change fix the compile related to #17,
where a cross compiler name was forced. On normal system it is mostly only "cc" and does not work.

Before it brought:
```
configure: error: /bin/bash ./addons/build/screensavers.rsxs/lib/rsxs-1.0/config.sub cc failed
```

With this change it checks about them and add it only if it is not "cc".

The way how it comes in #17 Is a bit of a hack way, but not sure if there is a better way.