### PR TITLE
[Matrix] final Matrix change to correct test builds and take as Version 19.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
       env:
         DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
       run: |
-        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
     - name: Checkout Kodi repo
       uses: actions/checkout@v2
       with:
         repository: xbmc/xbmc
-        ref: master
+        ref: Matrix
         path: xbmc
     - name: Checkout screensavers.rsxs repo
       uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
       run: |
         if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir -p build && cd build; fi
         if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=${{ github.workspace }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/xbmc/addons -DPACKAGE_ZIP=1 ${{ github.workspace }}/xbmc/cmake/addons; fi
-        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/Matrix/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep ${{ github.workspace }}/${app_id}; fi
     - name: Build
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       osx_image: xcode10.2
 
 before_install:
-  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libgl1-mesa-dev; fi
@@ -42,12 +42,12 @@ before_install:
 #
 before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
-  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/Matrix/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a collection of [Kodi](https://kodi.tv) screensaver addons.
 ## Build instructions
 
 When building the addon you have to use the correct branch depending on which version of Kodi you're building against.
-If you want to build the addon to be compatible with the latest kodi `master` commit, you need to checkout the branch with the current kodi codename.
+If you want to build the addon to be compatible with the latest kodi `Matrix` commit, you need to checkout the branch with the current kodi codename.
 Also make sure you follow this README from the branch in question.
 
 ### Linux
@@ -18,8 +18,8 @@ Also make sure you follow this README from the branch in question.
 The following instructions assume you will have built Kodi already in the `kodi-build` directory 
 suggested by the README.
 
-1. `git clone --branch master https://github.com/xbmc/xbmc.git`
-2. `git clone https://github.com/xbmc/screensavers.rsxs.git`
+1. `git clone --branch Matrix https://github.com/xbmc/xbmc.git`
+2. `git clone --branch Matrix https://github.com/xbmc/screensavers.rsxs.git`
 3. `cd screensavers.rsxs && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=screensavers.rsxs -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
 
     - script: |
         cd ..
-        git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git kodi
+        git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git kodi
         cd $(Build.SourcesDirectory)
         mkdir build
         cd build

--- a/screensaver.rsxs.biof/addon.xml.in
+++ b/screensaver.rsxs.biof/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.biof"
-  version="3.1.0"
+  version="19.0.0"
   name="Biof"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.busyspheres/addon.xml.in
+++ b/screensaver.rsxs.busyspheres/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.busyspheres"
-  version="3.1.0"
+  version="19.0.0"
   name="BusySpheres"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.colorfire/addon.xml.in
+++ b/screensaver.rsxs.colorfire/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.colorfire"
-  version="3.1.0"
+  version="19.0.0"
   name="Colorfire"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.cyclone/addon.xml.in
+++ b/screensaver.rsxs.cyclone/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.cyclone"
-  version="3.1.0"
+  version="19.0.0"
   name="Cyclone"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.drempels/addon.xml.in
+++ b/screensaver.rsxs.drempels/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.drempels"
-  version="3.1.0"
+  version="19.0.0"
   name="Drempels"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.euphoria/addon.xml.in
+++ b/screensaver.rsxs.euphoria/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.euphoria"
-  version="3.1.0"
+  version="19.0.0"
   name="Euphoria"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.feedback/addon.xml.in
+++ b/screensaver.rsxs.feedback/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.feedback"
-  version="3.1.0"
+  version="19.0.0"
   name="Feedback"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.fieldlines/addon.xml.in
+++ b/screensaver.rsxs.fieldlines/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.fieldlines"
-  version="3.1.0"
+  version="19.0.0"
   name="Fieldlines"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.flocks/addon.xml.in
+++ b/screensaver.rsxs.flocks/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.flocks"
-  version="3.1.0"
+  version="19.0.0"
   name="Flocks"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.flux/addon.xml.in
+++ b/screensaver.rsxs.flux/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.flux"
-  version="3.1.0"
+  version="19.0.0"
   name="Flux"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.helios/addon.xml.in
+++ b/screensaver.rsxs.helios/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.helios"
-  version="3.1.0"
+  version="19.0.0"
   name="Helios"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.hufosmoke/addon.xml.in
+++ b/screensaver.rsxs.hufosmoke/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.hufosmoke"
-  version="3.1.0"
+  version="19.0.0"
   name="Hufo Smoke"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.hufotunnel/addon.xml.in
+++ b/screensaver.rsxs.hufotunnel/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.hufotunnel"
-  version="3.1.0"
+  version="19.0.0"
   name="Hufo Tunnel"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.hyperspace/addon.xml.in
+++ b/screensaver.rsxs.hyperspace/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.hyperspace"
-  version="3.1.0"
+  version="19.0.0"
   name="Hyperspace"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.lattice/addon.xml.in
+++ b/screensaver.rsxs.lattice/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.lattice"
-  version="3.1.0"
+  version="19.0.0"
   name="Lattice"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.lorenz/addon.xml.in
+++ b/screensaver.rsxs.lorenz/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.lorenz"
-  version="3.1.0"
+  version="19.0.0"
   name="Lorenz Attractor"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.matrixview/addon.xml.in
+++ b/screensaver.rsxs.matrixview/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.matrixview"
-  version="3.1.0"
+  version="19.0.0"
   name="Matrix View"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.microcosm/addon.xml.in
+++ b/screensaver.rsxs.microcosm/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.microcosm.biof"
-  version="3.1.0"
+  version="19.0.0"
   name="Microcosm"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.plasma/addon.xml.in
+++ b/screensaver.rsxs.plasma/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.plasma"
-  version="3.1.0"
+  version="19.0.0"
   name="Plasma"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.skyrocket/addon.xml.in
+++ b/screensaver.rsxs.skyrocket/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.skyrocket"
-  version="3.1.0"
+  version="19.0.0"
   name="Skyrocket"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.solarwinds/addon.xml.in
+++ b/screensaver.rsxs.solarwinds/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.solarwinds"
-  version="3.1.0"
+  version="19.0.0"
   name="Solar Winds"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.spirographx/addon.xml.in
+++ b/screensaver.rsxs.spirographx/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.spirographx"
-  version="3.1.0"
+  version="19.0.0"
   name="SpiroGraphX"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensaver.rsxs.sundancer2/addon.xml.in
+++ b/screensaver.rsxs.sundancer2/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.rsxs.sundancer2"
-  version="3.1.0"
+  version="19.0.0"
   name="Sundancer 2"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/screensavers.rsxs/addon.xml.in
+++ b/screensavers.rsxs/addon.xml.in
@@ -3,7 +3,7 @@
 debian package build.-->
 <addon
   id="screensavers.rsxs"
-  version="3.1.0"
+  version="19.0.0"
   name="RSXS Screensaver collection"
   provider-name="Team Kodi">
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
This change the builds to final released Kodi Matrix.

Further is the version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.