### PR TITLE
[Matrix] impSurface.h: fix build with gcc11

### DIFF
--- a/lib/Implicit/impSurface.h
+++ b/lib/Implicit/impSurface.h
@@ -21,6 +21,7 @@
 #ifndef IMPSURFACE_H
 #define IMPSURFACE_H
 
+#include <cstddef>
 #include <functional>
 
 #ifdef WIN32


### PR DESCRIPTION
lib/Implicit/impSurface.h:44:9: error: 'size_t' does not name a type
   44 |         size_t vertex_data_size;

backport of https://github.com/xbmc/screensavers.rsxs/pull/51