### PR TITLE
Fix compiler error on UWP

### DIFF
--- a/src/euphoria/main.cpp
+++ b/src/euphoria/main.cpp
@@ -308,7 +308,8 @@ private:
 
 CWisp::CWisp()
 {
-  int i, j;
+  int i = 0;
+  int j = 0;
   float recHalfDens = 1.0f / (float(g_settings.dDensity) * 0.5f);
 
   m_vertices.resize(g_settings.dDensity+1);


### PR DESCRIPTION
Error was:

  D:\a\1\screensavers.rsxs\src\euphoria\main.cpp(320,1): error C4700: uninitialized local variable 'i' used
  D:\a\1\screensavers.rsxs\src\euphoria\main.cpp(321,1): error C4700: uninitialized local variable 'j' used