### PR TITLE
Fix build with CMake 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensavers.rsxs)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})

--- a/depends/common/bz2/CMakeLists.txt
+++ b/depends/common/bz2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(bzip2)
 
 if(NOT WIN32)

--- a/lib/Implicit/CMakeLists.txt
+++ b/lib/Implicit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5...4.0)
 
 project(Implicit)
 

--- a/lib/Rgbhsl/CMakeLists.txt
+++ b/lib/Rgbhsl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5...4.0)
 
 project(Rgbhsl)
 

--- a/lib/kodi/gui/gl/CMakeLists.txt
+++ b/lib/kodi/gui/gl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 
 project(kodiOpenGL)
 

--- a/lib/rsMath/CMakeLists.txt
+++ b/lib/rsMath/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5...4.0)
 
 project(rsMath)
 

--- a/src/biof/CMakeLists.txt
+++ b/src/biof/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.biof)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/busyspheres/CMakeLists.txt
+++ b/src/busyspheres/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.busyspheres)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/colorfire/CMakeLists.txt
+++ b/src/colorfire/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.colorfire)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/cyclone/CMakeLists.txt
+++ b/src/cyclone/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.cyclone)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/drempels/CMakeLists.txt
+++ b/src/drempels/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.drempels)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/euphoria/CMakeLists.txt
+++ b/src/euphoria/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.euphoria)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/feedback/CMakeLists.txt
+++ b/src/feedback/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.feedback)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/fieldlines/CMakeLists.txt
+++ b/src/fieldlines/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.fieldlines)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/flocks/CMakeLists.txt
+++ b/src/flocks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.flocks)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/flux/CMakeLists.txt
+++ b/src/flux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.flux)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/helios/CMakeLists.txt
+++ b/src/helios/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.helios)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/hufosmoke/CMakeLists.txt
+++ b/src/hufosmoke/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.hufosmoke)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/hufotunnel/CMakeLists.txt
+++ b/src/hufotunnel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.hufotunnel)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/hyperspace/CMakeLists.txt
+++ b/src/hyperspace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.hyperspace)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/lattice/CMakeLists.txt
+++ b/src/lattice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.lattice)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/lorenz/CMakeLists.txt
+++ b/src/lorenz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.lorenz)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/matrixview/CMakeLists.txt
+++ b/src/matrixview/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.matrixview)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/microcosm/CMakeLists.txt
+++ b/src/microcosm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.microcosm)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.plasma)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/skyrocket/CMakeLists.txt
+++ b/src/skyrocket/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.skyrocket)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/solarwinds/CMakeLists.txt
+++ b/src/solarwinds/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.solarwinds)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/spirographx/CMakeLists.txt
+++ b/src/spirographx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.spirographx)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/sundancer2/CMakeLists.txt
+++ b/src/sundancer2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(screensaver.rsxs.sundancer2)
 
 message(STATUS "--------------------------------------------------------------------------------")


### PR DESCRIPTION
Fixes build errors with CMake 4.x:

CMake Error at lib/Implicit/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

CMake Error at lib/Rgbhsl/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

CMake Error at lib/rsMath/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.