### PR TITLE
Fix build with CMake 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensavers.rsxs)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})

--- a/depends/common/bz2/CMakeLists.txt
+++ b/depends/common/bz2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(bzip2)
 
 if(NOT WIN32)

--- a/depends/windows/angle/CMakeLists.txt
+++ b/depends/windows/angle/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18)
 project(angle)
 
 message(STATUS "Used CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")

--- a/lib/Implicit/CMakeLists.txt
+++ b/lib/Implicit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 
 project(Implicit)
 

--- a/lib/Rgbhsl/CMakeLists.txt
+++ b/lib/Rgbhsl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 
 project(Rgbhsl)
 

--- a/lib/gli/CMakeLists.txt
+++ b/lib/gli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 cmake_policy(SET CMP0054 NEW)
 
 project(gli)

--- a/lib/glm/CMakeLists.txt
+++ b/lib/glm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 cmake_policy(VERSION 3.2)
 
 set(GLM_VERSION "0.9.9")

--- a/lib/glm/test/cmake/CMakeLists.txt
+++ b/lib/glm/test/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(test_find_glm)
 
 find_package(glm REQUIRED)

--- a/lib/kodi/gui/gl/CMakeLists.txt
+++ b/lib/kodi/gui/gl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 
 project(kodiOpenGL)
 

--- a/lib/rsMath/CMakeLists.txt
+++ b/lib/rsMath/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 
 project(rsMath)
 

--- a/src/biof/CMakeLists.txt
+++ b/src/biof/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.biof)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/busyspheres/CMakeLists.txt
+++ b/src/busyspheres/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.busyspheres)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/colorfire/CMakeLists.txt
+++ b/src/colorfire/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.colorfire)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/cyclone/CMakeLists.txt
+++ b/src/cyclone/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.cyclone)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/drempels/CMakeLists.txt
+++ b/src/drempels/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.drempels)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/euphoria/CMakeLists.txt
+++ b/src/euphoria/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.euphoria)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/feedback/CMakeLists.txt
+++ b/src/feedback/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.feedback)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/fieldlines/CMakeLists.txt
+++ b/src/fieldlines/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.fieldlines)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/flocks/CMakeLists.txt
+++ b/src/flocks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.flocks)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/flux/CMakeLists.txt
+++ b/src/flux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.flux)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/helios/CMakeLists.txt
+++ b/src/helios/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.helios)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/hufosmoke/CMakeLists.txt
+++ b/src/hufosmoke/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.hufosmoke)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/hufotunnel/CMakeLists.txt
+++ b/src/hufotunnel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.hufotunnel)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/hyperspace/CMakeLists.txt
+++ b/src/hyperspace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.hyperspace)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/lattice/CMakeLists.txt
+++ b/src/lattice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.lattice)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/lorenz/CMakeLists.txt
+++ b/src/lorenz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.lorenz)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/matrixview/CMakeLists.txt
+++ b/src/matrixview/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.matrixview)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/microcosm/CMakeLists.txt
+++ b/src/microcosm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.microcosm)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.plasma)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/skyrocket/CMakeLists.txt
+++ b/src/skyrocket/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.skyrocket)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/solarwinds/CMakeLists.txt
+++ b/src/solarwinds/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.solarwinds)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/spirographx/CMakeLists.txt
+++ b/src/spirographx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.spirographx)
 
 message(STATUS "--------------------------------------------------------------------------------")

--- a/src/sundancer2/CMakeLists.txt
+++ b/src/sundancer2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(screensaver.rsxs.sundancer2)
 
 message(STATUS "--------------------------------------------------------------------------------")


### PR DESCRIPTION
- some CMakeLists.txt were missed in the previous update
- ref: 0635422964b6797d693866483d16dff51bcf4b57
- align the minimum CMake version to that used by kodi (3.18).